### PR TITLE
实验性的加密消息支持

### DIFF
--- a/src/wx-msg-crypt.coffee
+++ b/src/wx-msg-crypt.coffee
@@ -1,0 +1,110 @@
+crypto = require 'crypto'
+xml2js = require 'xml2js'
+
+# wrap the PKCS7 encoder/decoder.
+PKCS7 = do ->
+
+  block_size = 32
+
+  # encode with PKCS7
+  encode: (data) ->
+    amount_to_pad = block_size - (data.length % block_size)
+    if amount_to_pad == 0
+      amount_to_pad = block_size
+    buf = new Buffer(amount_to_pad)
+    buf.fill String.fromCharCode(amount_to_pad)
+    Buffer.concat [data, buf]
+
+  # decode with PKCS7
+  decode: (data) ->
+    pad = data.readUInt8 data.length - 1
+    if pad < 1 || pad > 32
+      pad = 0
+    console.log pad
+    data.slice 0, data.length - pad
+
+class Prpcrypt
+
+  constructor: (key) ->
+    @key = new Buffer(key + '=', 'base64')
+
+  get_random_str = ->
+    str = ''
+    str_pol = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz"
+    for i in [0..15]
+      str += str_pol[parseInt(Math.random() * str_pol.length)]
+    str
+
+  encrypt: (text, appid) ->
+    # assemble the encrypted message.
+    msg_len = 16 + 4 + Buffer.byteLength(text) + appid.length
+    buf = new Buffer(msg_len)
+    buf.write get_random_str(), 0
+    buf.writeUInt32BE Buffer.byteLength(text), 16
+    buf.write text, 20
+    buf.write appid, Buffer.byteLength(text) + 20
+    # Encrypt with PKCS7 and AES256 CBC.
+    iv = @key.slice(0, 16)
+    #pkc_encoder = new PKCS7Encoder()
+    buf = PKCS7.encode buf
+    cipher = crypto.createCipheriv 'aes-256-cbc', @key, iv
+    cipher.setAutoPadding false
+    cipherChunks = [
+      cipher.update buf, 'binary', 'base64'
+      cipher.final 'base64'
+    ]
+    cipherChunks.join ''
+
+  decrypt: (text, appid) ->
+    # Decrypt with AES256 CBC
+    iv = @key.slice(0, 16)
+    decipher = crypto.createDecipheriv 'aes-256-cbc', @key, iv
+    decipher.setAutoPadding false
+    plainChunks = [
+      decipher.update text, 'base64'
+      decipher.final()
+    ]
+    buf = Buffer.concat plainChunks
+    # extract the message part.
+    buf = PKCS7.decode buf
+    buf = buf.slice 20, buf.length - appId.length
+    buf.toString 'utf8'
+
+generated_signature = (token, timestamp, nonce, encrypt) ->
+  sha1 = crypto.createHash 'sha1'
+  sha1.update [token, timestamp, nonce, encrypt].sort().join ''
+  sha1.digest 'hex'
+
+class WXBizMsgCrypt
+
+  constructor: (@token, @key, @appId) ->
+    if @key.length != 43
+      throw 'Key is not valid.'
+
+  encrypt: (msg, timestamp, nonce) ->
+    pc = new Prpcrypt @key
+    encrypt = pc.encrypt msg, @appId
+    signature = generated_signature @token, timestamp, nonce, encrypt
+    "<xml>
+      <Encrypt><![CDATA[#{encrypt}]]></Encrypt>
+      <MsgSignature><![CDATA[#{signature}]]></MsgSignature>
+      <TimeStamp>#{timestamp}</TimeStamp>
+      <Nonce><![CDATA[#{nonce}]]></Nonce>
+    </xml>"
+
+  decrypt: (msg, callback) ->
+    xml2js.parseString msg, (err, result) ->
+      throw err if err
+      xml = result.xml
+      if xml.Encrypt
+        signature = generated_signature @token, xml.TimeStamp, xml.Nonce, xml.Encrypt
+        unless signature == msg_signature
+          callback 'Signuature is not valid.', null
+        else
+          pc = new Prpcrypt @key
+          xml2js.parseString pc.decrypt(xml.Encrypt, @appId), callback
+      else
+        callback 'Not encrypted.', null
+
+# Expose the class.
+module.exports = WXBizMsgCrypt

--- a/src/wx.coffee
+++ b/src/wx.coffee
@@ -32,6 +32,7 @@ api_binary = 'http://file.api.weixin.qq.com/cgi-bin'
 #   - `token`
 #   - `app_id`
 #   - `app_secret`
+#   - `encoding_aes_key` （若提供则使用加密方式）
 #
 # + `redis`：`REDIS`连接参数（默认本地连接），包含：
 #
@@ -41,7 +42,7 @@ api_binary = 'http://file.api.weixin.qq.com/cgi-bin'
 #
 # + `populate_user`：是否自动组装用户信息，默认`on`；
 # + `debug`：调试模式，输出调试信息。
-module.exports = ({token, app_id, app_secret, redis_options, populate_user, debug}) ->
+module.exports = ({token, app_id, app_secret, encoding_aes_key, redis_options, populate_user, debug}) ->
 
   # ### REDIS客户端
   #
@@ -55,6 +56,11 @@ module.exports = ({token, app_id, app_secret, redis_options, populate_user, debu
 
   # 访问口令局部缓存。
   access_token = null
+
+  # 消息加密解密器
+  if encoding_aes_key
+    WXMsgCrypt = require './wx-msg-crypto'
+    wx_msg_crypt = new WXMsgCrypt token, encoding_aes_key, app_id
 
   #（默认）响应消息前，先通过微信接口组装用户信息。
   populate_user ?= on
@@ -385,7 +391,7 @@ module.exports = ({token, app_id, app_secret, redis_options, populate_user, debu
       console.info string if debug
 
       # 2. 解析请求XML内容。
-      xml2js.parseString string, (err, result) =>
+      callback = (err, result) =>
         return res.status(400).end() if err
 
         # 3. 按消息内容增补请求对象。
@@ -626,6 +632,12 @@ module.exports = ({token, app_id, app_secret, redis_options, populate_user, debu
         else
           process_message wx.user message.from_user_name
 
+      # 如果存在密钥，就进行解密
+      if encoding_aes_key
+        wx_msg_crypt.decrypt string, callback
+      else
+        xml2js.parseString string, callback
+
   # ### 媒体标识符格式
   regex_media_id = /^[\w\_\-]{64}$/
 
@@ -656,13 +668,22 @@ module.exports = ({token, app_id, app_secret, redis_options, populate_user, debu
     # + 发送方用户名；
     # + 接收方用户名；
     # + 消息创建时间。
-    message = (message) ->
-      "<xml>
-      <ToUserName><![CDATA[#{req.from_user_name}]]></ToUserName>
-      <FromUserName><![CDATA[#{req.to_user_name}]]></FromUserName>
-      <CreateTime>#{~~(Date.now() / 1000)}</CreateTime>
-      #{message}
-      </xml>"
+    if encoding_aes_key
+      message = (message) ->
+        wx_msg_crypt.encypt "<xml>
+          <ToUserName><![CDATA[#{req.from_user_name}]]></ToUserName>
+          <FromUserName><![CDATA[#{req.to_user_name}]]></FromUserName>
+          <CreateTime>#{~~(Date.now() / 1000)}</CreateTime>
+          #{message}
+          </xml>"
+    else
+      message = (message) ->
+        "<xml>
+        <ToUserName><![CDATA[#{req.from_user_name}]]></ToUserName>
+        <FromUserName><![CDATA[#{req.to_user_name}]]></FromUserName>
+        <CreateTime>#{~~(Date.now() / 1000)}</CreateTime>
+        #{message}
+        </xml>"
 
     # ### 回复文本
     text: (text) ->
@@ -760,7 +781,7 @@ module.exports = ({token, app_id, app_secret, redis_options, populate_user, debu
     # 响应设备发来的消息
     device: (content) ->
       content = base64.encode(content)
-      
+
       @send message "<MsgType><![CDATA[device_text]]></MsgType>
         <DeviceType><![CDATA[#{req.device_type}]]></DeviceType>
         <DeviceID><![CDATA[#{req.device_id}]]></DeviceID>


### PR DESCRIPTION
根据微信 PHP 示例代码，把加密消息引入到当前版本中。

测试代码：

```
WXBizMsgCrypt = require '../src/wx-msg-crypt'

encodingAesKey = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG"
token = "pamtest"
timeStamp = "1409304348"
nonce = "xxxxxx"
appId = "wxb11529c136998cb6"
text = "<xml><a>test</a><ToUserName><![CDATA[oia2Tj我是中文jewbmiOUlr6X-1crbLOvLw]]></ToUserName><FromUserName><![CDATA[gh_7f083739789a]]></FromUserName><CreateTime>1407743423</CreateTime><MsgType><![CDATA[video]]></MsgType><Video><MediaId><![CDATA[eYJ1MbwPRJtOvIEabaxHs7TX2D-HV71s79GUxqdUkjm6Gs2Ed1KF3ulAOA9H1xG0]]></MediaId><Title><![CDATA[testCallBackReplyVideo]]></Title><Description><![CDATA[testCallBackReplyVideo]]></Description></Video></xml>"

wx = new WXBizMsgCrypt(token, encodingAesKey, appId)
encrypt = wx.encrypt text, timeStamp, nonce
console.log encrypt

console.log '==='

wx.decrypt encrypt, (err, result) ->
  unless err
    console.log JSON.stringify result
  else
    console.log err
```

加密模块应该可以通过，但是如何整合的话可能还需要讨论。

另参见 #19 。