### PR TITLE
启动应用的时候强制更新 access token

### DIFF
--- a/src/wx.coffee
+++ b/src/wx.coffee
@@ -184,6 +184,7 @@ module.exports = ({token, app_id, app_secret, encoding_aes_key, redis_options, p
   wx = router = express.Router()
 
   # ### 获取访问令牌
+  redis_client.del key_access_token
   lock_fetching = 5
   do fetch_access_token = =>
     redis_client.watch key_access_token


### PR DESCRIPTION
应用启动的时候应该更新 access token，以防止 access token 被外界修改导致问题。另外，在出现 40001 错误的时候，应该更新 access token，例如客服消息，但是这部分需要继续修改 fetch_access_token 的实现以防止多次调用导致的问题。
